### PR TITLE
Add Summer 2026 season

### DIFF
--- a/data/results.ts
+++ b/data/results.ts
@@ -635,4 +635,32 @@ export const results: Result[] = [
     coverPhotoUrl:
       'https://refaleikarnir.sirv.com/coverPhotos/2025-winter.jpeg',
   },
+  {
+    year: 2026,
+    teams: [
+      {
+        teamColor: 'BLACK',
+        teamPlace: 0,
+        teamPlayers: [players.jonni, players.atli, players.maggi],
+      },
+      {
+        teamColor: 'WHITE',
+        teamPlace: 1,
+        teamPlayers: [players.aegir, players.danni],
+      },
+      {
+        teamColor: 'RED',
+        teamPlace: 2,
+        teamPlayers: [players.arnar, players.vikingur],
+      },
+      {
+        teamColor: 'SILVER',
+        teamPlace: 3,
+        teamPlayers: [players.gaui, players.krissi],
+      },
+    ],
+    season: 'summer',
+    challenges: ['Keila 🎳', 'Fótboltagolf ⛳', 'Dodgeball 🏐'],
+    coverPhotoUrl: 'https://refaleikarnir.sirv.com/coverPhotos/2026-summer.png',
+  },
 ]

--- a/data/results.ts
+++ b/data/results.ts
@@ -645,12 +645,12 @@ export const results: Result[] = [
       },
       {
         teamColor: 'WHITE',
-        teamPlace: 1,
+        teamPlace: 0,
         teamPlayers: [players.aegir, players.danni, players.gaui],
       },
       {
         teamColor: 'RED',
-        teamPlace: 2,
+        teamPlace: 0,
         teamPlayers: [players.arnar, players.vikingur, players.krissi],
       },
     ],

--- a/data/results.ts
+++ b/data/results.ts
@@ -646,17 +646,12 @@ export const results: Result[] = [
       {
         teamColor: 'WHITE',
         teamPlace: 1,
-        teamPlayers: [players.aegir, players.danni],
+        teamPlayers: [players.aegir, players.danni, players.gaui],
       },
       {
         teamColor: 'RED',
         teamPlace: 2,
-        teamPlayers: [players.arnar, players.vikingur],
-      },
-      {
-        teamColor: 'SILVER',
-        teamPlace: 3,
-        teamPlayers: [players.gaui, players.krissi],
+        teamPlayers: [players.arnar, players.vikingur, players.krissi],
       },
     ],
     season: 'summer',


### PR DESCRIPTION
## Summary

- Adds Summer 2026 season entry to `data/results.ts`
- 3 games: Keila 🎳, Fótboltagolf ⛳, Dodgeball 🏐
- 3 teams of 3 players each (BLACK, WHITE, RED) — randomized placeholders until teams are confirmed
- Cover photo set to `2026-summer.png` on Sirv

## Test plan

- [ ] Teams and player assignments look correct
- [ ] Update team placements and challenge results after the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)