### PR TITLE
Update 2026 summer game teams and results

### DIFF
--- a/data/results.ts
+++ b/data/results.ts
@@ -640,17 +640,17 @@ export const results: Result[] = [
     teams: [
       {
         teamColor: 'BLACK',
-        teamPlace: 2,
+        teamPlace: 1,
         teamPlayers: [players.gaui, players.jonni, players.atli],
       },
       {
         teamColor: 'WHITE',
-        teamPlace: 3,
+        teamPlace: 2,
         teamPlayers: [players.danni, players.maggi, players.arnar],
       },
       {
         teamColor: 'RED',
-        teamPlace: 1,
+        teamPlace: 0,
         teamPlayers: [players.aegir, players.krissi, players.vikingur],
       },
     ],

--- a/data/results.ts
+++ b/data/results.ts
@@ -640,22 +640,50 @@ export const results: Result[] = [
     teams: [
       {
         teamColor: 'BLACK',
-        teamPlace: 0,
+        teamPlace: 2,
         teamPlayers: [players.gaui, players.jonni, players.atli],
       },
       {
         teamColor: 'WHITE',
-        teamPlace: 0,
+        teamPlace: 3,
         teamPlayers: [players.danni, players.maggi, players.arnar],
       },
       {
         teamColor: 'RED',
-        teamPlace: 0,
+        teamPlace: 1,
         teamPlayers: [players.aegir, players.krissi, players.vikingur],
       },
     ],
     season: 'summer',
-    challenges: ['Keila 🎳', 'Fótboltagolf ⛳', 'Dodgeball 🏐'],
+    challenges: [
+      {
+        name: 'Keila',
+        emoji: '🎳',
+        teamResults: [
+          { color: 'WHITE', points: 10 },
+          { color: 'RED', points: 17 },
+          { color: 'BLACK', points: 18 },
+        ],
+      },
+      {
+        name: 'Fótboltagolf',
+        emoji: '⛳',
+        teamResults: [
+          { color: 'WHITE', points: 14.5 },
+          { color: 'RED', points: 17.5 },
+          { color: 'BLACK', points: 13 },
+        ],
+      },
+      {
+        name: 'Dodgeball',
+        emoji: '🏐',
+        teamResults: [
+          { color: 'WHITE', points: 12 },
+          { color: 'RED', points: 24 },
+          { color: 'BLACK', points: 9 },
+        ],
+      },
+    ],
     coverPhotoUrl: 'https://refaleikarnir.sirv.com/coverPhotos/2026-summer.png',
   },
 ]


### PR DESCRIPTION
## Summary

- Updated team setup for the 2026 summer games
- Added challenge scores and final standings from the scoresheet

## Teams
- **Red**: Aegir, Krissi, Vikingur
- **Black**: Gaui, Jonni, Atli
- **White**: Danny, Maggi, Arnar

## Results

| Challenge | White | Red | Black |
|---|---|---|---|
| Keila 🎳 | 10 | 17 | 18 |
| Fótboltagolf ⛳ | 14.5 | 17.5 | 13 |
| Dodgeball 🏐 | 12 | 24 | 9 |
| **Lokastig** | **36.5** | **58.5 🏆** | **40** |

Red team wins!

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMzeNm5naErYTd8QAXQLdb)_